### PR TITLE
add support to generate svgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ and then run as
 ```
 > elk -f examples/graph.json
 ```
+
+## Generate SVGs
+You can automatically generate a simple SVG of the laid out graph using the `-s <output.svg>` option. A css file for styling may be supplied using the `-c <style.css>` file. The examples folder contains an example style file.

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,7 +20,8 @@ const usage = "Supply an elkj graph directly with the -g option or read in an el
 const options = yargs.usage(usage)
                      .option("g", {alias: "graph", describe: "Input elkj graph", type: "string", demandOption: false})
                      .option("f", {alias: "file", describe: "Input file", type: "string", demandOption: false})
-                     .option("s", {alias: "svg", describe: "Render output as svg and write to file", type: "string", demandOPtion: false})
+                     .option("s", {alias: "svg", describe: "Render output as svg and write to file", type: "string", demandOption: false})
+                     .option("c", {alias: "css", describe: "CSS to be used for svg", type: "string", demandOption: false})
                      .help(true)
                      .argv;
 
@@ -51,7 +52,15 @@ elk.layout(graph)
        .then(function(g) {
             if (options.s !== undefined) {
                 let renderer = new elksvg.Renderer();
-                let svg = renderer.toSvg(g);
+                let svg = {};
+                if (options.c !== undefined) {
+                    let css = fs.readFileSync(options.c, "utf-8");
+                    svg = renderer.toSvg(g,
+                        styles=css,
+                    );
+                } else {
+                    svg = renderer.toSvg(g);
+                }
                 fs.writeFileSync(options.s, svg, "utf-8");
             }
             console.log(JSON.stringify(g))

--- a/bin/index.js
+++ b/bin/index.js
@@ -12,6 +12,7 @@
 const fs = require("fs");
 const yargs = require("yargs");
 const ELK = require("elkjs");
+const elksvg = require("elkjs-svg");
 
 const elk = new ELK();
 
@@ -19,6 +20,7 @@ const usage = "Supply an elkj graph directly with the -g option or read in an el
 const options = yargs.usage(usage)
                      .option("g", {alias: "graph", describe: "Input elkj graph", type: "string", demandOption: false})
                      .option("f", {alias: "file", describe: "Input file", type: "string", demandOption: false})
+                     .option("s", {alias: "svg", describe: "Render output as svg and write to file", type: "string", demandOPtion: false})
                      .help(true)
                      .argv;
 
@@ -46,5 +48,12 @@ if (options.g !== undefined) {
     process.exit();
 }
 elk.layout(graph)
-       .then(function(g) {console.log(JSON.stringify(g))})
+       .then(function(g) {
+            if (options.s !== undefined) {
+                let renderer = new elksvg.Renderer();
+                let svg = renderer.toSvg(g);
+                fs.writeFileSync(options.s, svg, "utf-8");
+            }
+            console.log(JSON.stringify(g))
+        })
        .catch(console.error);

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*******************************************************************************
- * Copyright (c) 2017 Kiel University and others.
+ * Copyright (c) 2024 Kiel University and others.
  * 
  * This program and the accompanying materials are made 
  * available under the terms of the Eclipse Public License 2.0 

--- a/examples/example-style.css
+++ b/examples/example-style.css
@@ -1,0 +1,35 @@
+rect {
+    opacity: 0.8;
+    fill: #68d639;
+    stroke-width: 1;
+    stroke: #222222;
+}
+
+rect.port {
+    opacity: 1;
+    fill: #0c9a55;
+}
+
+text {
+    font-size: 10px;
+    font-family: sans-serif;
+    /* in elk's coordinates "hanging" would be the correct value" */
+    dominant-baseline: hanging;
+    text-align: left;
+}
+
+g.port>text {
+    font-size: 8px;
+}
+
+polyline {
+    fill: none;
+    stroke: rgb(104, 2, 115);
+    stroke-width: 1;
+}
+
+path {
+    fill: none;
+    stroke: rgb(104, 2, 115);
+    stroke-width: 1;
+}

--- a/examples/graph-radial.json
+++ b/examples/graph-radial.json
@@ -1,0 +1,15 @@
+{
+  "id": "root",
+  "layoutOptions": { "elk.algorithm": "radial" },
+  "children": [
+    { "id": "n1", "width": 10, "height": 10 },
+    { "id": "n2", "width": 30, "height": 30 },
+    { "id": "n3", "width": 30, "height": 30 },
+    { "id": "n4", "width": 30, "height": 30 }
+  ],
+  "edges": [
+    { "id": "e1", "sources": [ "n1" ], "targets": [ "n2" ] },
+    { "id": "e2", "sources": [ "n1" ], "targets": [ "n3" ] },
+    { "id": "e2", "sources": [ "n1" ], "targets": [ "n4" ] }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "elk-cli",
+  "name": "@kieler/elk-cli",
   "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -44,6 +44,21 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.1.tgz",
       "integrity": "sha512-JWKDyqAdltuUcyxaECtYG6H4sqysXSLeoXuGUBfRNESMTkj+w+qdb0jya8Z/WI0jVd03WQtCGhS6FOFtlhD5FQ=="
+    },
+    "elkjs-svg": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/elkjs-svg/-/elkjs-svg-0.2.1.tgz",
+      "integrity": "sha512-5GdjTsA2JpWm9i8nd08LBWRNDIXf/aBmkAPyZyRPXXZyNFVd+zGChUwQ2Rw6QP+0lmUlSDXCAaslWVwhJ9R9QQ==",
+      "requires": {
+        "elkjs": "^0.7.0"
+      },
+      "dependencies": {
+        "elkjs": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.7.1.tgz",
+          "integrity": "sha512-lD86RWdh480/UuRoHhRcnv2IMkIcK6yMDEuT8TPBIbO3db4HfnVF+1lgYdQi99Ck0yb+lg5Eb46JCHI5uOsmAw=="
+        }
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "EPL-2.0",
   "dependencies": {
     "elkjs": "^0.9.1",
+    "elkjs-svg": "^0.2.1",
     "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
Uses [elkjs-svg](https://www.npmjs.com/package/elkjs-svg) to generate an svg file if the corresponding option is set.